### PR TITLE
Fix bug #8 in ScoreBoard class

### DIFF
--- a/src/main/java/cs/ualberta/cmput402/tictactoe/board/ScoreBoard.java
+++ b/src/main/java/cs/ualberta/cmput402/tictactoe/board/ScoreBoard.java
@@ -1,7 +1,6 @@
 package cs.ualberta.cmput402.tictactoe.board;
 
 public class ScoreBoard {
-    public enum Player {X, O, NONE};
     private int X_win,X_loss,X_tie;
     private int O_win,O_loss,O_tie;
 
@@ -15,7 +14,7 @@ public class ScoreBoard {
         O_tie=0;
     }
 
-    public void score(Player player)
+    public void score(Board.Player player)
     {
         switch(player)
         {


### PR DESCRIPTION
Fix bug #8 in ScoreBoard class
Use Board.Player instead of defining a new one.